### PR TITLE
Add basic test of template parsing

### DIFF
--- a/pkg/component_test.go
+++ b/pkg/component_test.go
@@ -1,0 +1,42 @@
+package serverfullgw
+
+import (
+	"context"
+	"testing"
+)
+
+func TestComponentDoesNotAllowInvalidTemplates(t *testing.T) {
+	ctx := context.Background()
+	// The range of acceptable template strings is fairly broad which
+	// makes it hard to validate all possible inputs. At the very
+	// least we can ensure that any valid go template string is
+	// accepted and invalid strings are not.
+	text := `#! no closing characters`
+	c := &Component{}
+	conf := c.Settings()
+
+	conf.Request = text
+	conf.Success = `{"status": 200, "body": {"v2":"#!.Response.Body.v!#"}}`
+	conf.Error = `{"status": 500, "bodyPassthrough": true}`
+
+	_, err := c.New(ctx, conf)
+	if err == nil {
+		t.Error("did not fail on bad request template")
+	}
+
+	conf.Request = `{}`
+	conf.Success = text
+	conf.Error = `{"status": 500, "bodyPassthrough": true}`
+	_, err = c.New(ctx, conf)
+	if err == nil {
+		t.Error("did not fail on bad success template")
+	}
+
+	conf.Request = `{}`
+	conf.Success = `{"status": 200, "body": {"v2":"#!.Response.Body.v!#"}}`
+	conf.Error = text
+	_, err = c.New(ctx, conf)
+	if err == nil {
+		t.Error("did not fail on bad error template")
+	}
+}


### PR DESCRIPTION
There's not yet a great way to test for all possible ways a template
could be invalid. At the very least we can gate against invalid syntax.
This patch adds a test to ensure that we continue to fail component
creation when at least one of the template strings are invalid.