### PR TITLE
Fix interpretation of Content-Length header

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -186,9 +186,12 @@
   version = "v1.3.0"
 
 [[projects]]
-  digest = "1:972c2427413d41a1e06ca4897e8528e5a1622894050e2f527b38ddf0f343f759"
+  digest = "1:5da8ce674952566deae4dbc23d07c85caafc6cfa815b0b3e03e41979cedb8750"
   name = "github.com/stretchr/testify"
-  packages = ["assert"]
+  packages = [
+    "assert",
+    "require",
+  ]
   pruneopts = "UT"
   revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
   version = "v1.3.0"
@@ -225,6 +228,7 @@
     "github.com/asecurityteam/transportd/pkg/components",
     "github.com/golang/mock/gomock",
     "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -5,3 +5,7 @@
 [[constraint]]
   name = "github.com/asecurityteam/transportd"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/stretchr/testify"
+  version = "1.3.0"

--- a/pkg/http_test.go
+++ b/pkg/http_test.go
@@ -237,9 +237,16 @@ func TestLambdaTransport_RoundTrip(t *testing.T) {
 						}
 					},
 				).Return(&http.Response{
-					StatusCode:    200,
-					Body:          ioutil.NopCloser(bytes.NewBufferString(lambdaResponse)),
-					ContentLength: 2,
+					StatusCode: 200,
+					Body:       ioutil.NopCloser(bytes.NewBufferString(lambdaResponse)),
+					// Setting ContentLength to zero in order to test for cases where the body
+					// is non-zero but the length is not reported. A Go HTTP server usually
+					// writes the content length for responses but only if the body is under
+					// a certain size and there are no calls to Flush(). Larger payloads, then,
+					// result in a missing content-length value. Previous versions of the project
+					// checked the ContentLength attributes in a switch which failed when the
+					// body was populated but mis-reported.
+					ContentLength: 0,
 				}, nil)
 			}
 

--- a/pkg/template.go
+++ b/pkg/template.go
@@ -78,11 +78,15 @@ func NewResponse(r *http.Response) (Response, error) {
 // NewRequest converts and http.Request into a template Request.
 func NewRequest(urlParamFn func(context.Context) map[string]string, r *http.Request) (Request, error) {
 	d := make(map[string]interface{})
-	if r.ContentLength > 0 {
-		b, err := ioutil.ReadAll(r.Body)
+	var b []byte
+	var err error
+	if r.Body != nil {
+		b, err = ioutil.ReadAll(r.Body)
 		if err != nil {
 			return emptyRequest, err
 		}
+	}
+	if len(b) > 0 {
 		err = json.Unmarshal(b, &d)
 		if err != nil {
 			return emptyRequest, err

--- a/pkg/template.go
+++ b/pkg/template.go
@@ -58,11 +58,11 @@ type TemplateContext struct {
 // NewResponse converts an http.Response into a template Response.
 func NewResponse(r *http.Response) (Response, error) {
 	d := make(map[string]interface{})
-	if r.ContentLength > 0 {
-		b, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			return emptyResponse, err
-		}
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return emptyResponse, err
+	}
+	if len(b) > 0 {
 		err = json.Unmarshal(b, &d)
 		if err != nil {
 			return emptyResponse, err

--- a/tests/lambda_test.go
+++ b/tests/lambda_test.go
@@ -13,6 +13,7 @@ import (
 	serverfullgw "github.com/asecurityteam/serverfull-gateway/pkg"
 	transportd "github.com/asecurityteam/transportd/pkg"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLambda(t *testing.T) {
@@ -31,7 +32,7 @@ func TestLambda(t *testing.T) {
 
 	done := make(chan error)
 	rt, err := transportd.New(context.Background(), spec, serverfullgw.Lambda)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	rt.Exit = func() chan error {
 		return done
 	}
@@ -39,7 +40,7 @@ func TestLambda(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodPost, "http://localhost:9090", http.NoBody)
 	resp, err := http.DefaultClient.Do(req)
-	assert.Nil(t, err)
+	require.Nil(t, err)
 	defer resp.Body.Close()
 
 	respB, _ := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
The previous version checked for content-length as a gate before
attempting to read from the response body stream. However, not all
servers report content-length correctly and automatically. In these
cases the interpretation of the response body was skipped by the
content-length check. This change adjusts the switch to check the length
of the content read from the body rather than the content-length header.