### PR TITLE
Update test after switch to components-*

### DIFF
--- a/tests/lambda_test.go
+++ b/tests/lambda_test.go
@@ -33,9 +33,7 @@ func TestLambda(t *testing.T) {
 	done := make(chan error)
 	rt, err := transportd.New(context.Background(), spec, serverfullgw.Lambda)
 	require.Nil(t, err)
-	rt.Exit = func() chan error {
-		return done
-	}
+	rt.Exit = done
 	go func() { _ = rt.Run() }()
 
 	req, _ := http.NewRequest(http.MethodPost, "http://localhost:9090", http.NoBody)

--- a/tests/port_test.go
+++ b/tests/port_test.go
@@ -1,0 +1,24 @@
+// +build integration
+
+package tests
+
+import (
+	"fmt"
+	"net"
+)
+
+// Copied from https://github.com/phayes/freeport.
+// BSD Licensed: https://github.com/phayes/freeport/blob/master/LICENSE.md
+func getPort() (string, error) {
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	if err != nil {
+		return "", err
+	}
+
+	l, err := net.ListenTCP("tcp", addr)
+	if err != nil {
+		return "", err
+	}
+	defer l.Close()
+	return fmt.Sprintf("%d", l.Addr().(*net.TCPAddr).Port), nil
+}

--- a/tests/specs/complete.yaml
+++ b/tests/specs/complete.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 x-runtime:
   httpserver:
-    address: ":9090"
+    address: "127.0.0.1:${TEST_SERVER_PORT}"
   logger:
     level: "INFO"
     output: "STDOUT"


### PR DESCRIPTION
We missed a migration from the old runhttp monolith to the individual
component repos. This corrects the tests for a change in the interfaces
used.