### PR TITLE
Psd 511/update transportd version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM asecurityteam/sdcli:v1 AS BUILDER
+FROM asecurityteam/sdcli:v1.1.1 AS BUILDER
 RUN mkdir -p /go/src/github.com/asecurityteam/serverfull-gateway
 WORKDIR /go/src/github.com/asecurityteam/serverfull-gateway
 COPY --chown=sdcli:sdcli . .

--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,19 @@ dep:
 	docker run -ti \
         --mount src="$(DIR)",target="$(DIR)",type="bind" \
         -w "$(DIR)" \
-        asecurityteam/sdcli:v1 go dep
+        asecurityteam/sdcli:v1.1.1 go dep
 
 lint:
 	docker run -ti \
         --mount src="$(DIR)",target="$(DIR)",type="bind" \
         -w "$(DIR)" \
-        asecurityteam/sdcli:v1 go lint
+        asecurityteam/sdcli:v1.1.1 go lint
 
 test:
 	docker run -ti \
         --mount src="$(DIR)",target="$(DIR)",type="bind" \
         -w "$(DIR)" \
-        asecurityteam/sdcli:v1 go test
+        asecurityteam/sdcli:v1.1.1 go test
 
 integration:
 	DIR=$(DIR) \
@@ -32,7 +32,7 @@ coverage:
 	docker run -ti \
         --mount src="$(DIR)",target="$(DIR)",type="bind" \
         -w "$(DIR)" \
-        asecurityteam/sdcli:v1 go coverage
+        asecurityteam/sdcli:v1.1.1 go coverage
 
 doc: ;
 

--- a/docker-compose.it.yml
+++ b/docker-compose.it.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   test:
-    image: asecurityteam/sdcli:v1
+    image: asecurityteam/sdcli:v1.1.1
     command: go integration
     working_dir: ${DIR}
     volumes:

--- a/go.mod
+++ b/go.mod
@@ -5,12 +5,10 @@ go 1.12
 require (
 	github.com/asecurityteam/component-aws v0.1.0
 	github.com/asecurityteam/httpstats v0.0.0-20191007213332-05cb203c96fb // indirect
-	github.com/asecurityteam/transportd v1.0.0
+	github.com/asecurityteam/transportd v1.0.1
 	github.com/aws/aws-sdk-go v1.25.9
 	github.com/getkin/kin-openapi v0.2.1-0.20190729060947-8785b416cb32 // indirect
 	github.com/golang/mock v1.4.0
-	github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da // indirect
-	github.com/rs/cors v1.7.0 // indirect
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/net v0.0.0-20191009170851-d66e71096ffb // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,12 @@ github.com/asecurityteam/settings v0.4.0 h1:L7fK4WqkvnvglBrfLBgp77LUDR2cxfSNWGFe
 github.com/asecurityteam/settings v0.4.0/go.mod h1:frhlF5kT7WvdiRX3eQlCOjSppbYUfxxjM9xKTvYjcGo=
 github.com/asecurityteam/transport v1.3.0 h1:UYcKPxnAEeGVkicefWtIL/nJys/BlwYUdNxLwvi49so=
 github.com/asecurityteam/transport v1.3.0/go.mod h1:nR1f2IiW3IIw2VxC7NOkZnwRhXanNE6XdnnIZctKbIU=
+github.com/asecurityteam/transport v1.3.1 h1:v3wG7xjq+RQMaZcv9sA5OmfaPx//PodClUKFK5oGPtw=
+github.com/asecurityteam/transport v1.3.1/go.mod h1:nR1f2IiW3IIw2VxC7NOkZnwRhXanNE6XdnnIZctKbIU=
 github.com/asecurityteam/transportd v1.0.0 h1:TwjruVMFpZ7mNSIsdKokwqjAhDtLRAQ76hTsmfLbvg4=
 github.com/asecurityteam/transportd v1.0.0/go.mod h1:mYu7W+jLQLEN7huup+JKPBLQGvA0+8+35Yu74G2wU+8=
+github.com/asecurityteam/transportd v1.0.1 h1:e7Yg6myAo1DsvNGtCKEi9ymf+M8W+3s2ixmiDKHVWL8=
+github.com/asecurityteam/transportd v1.0.1/go.mod h1:M1HNg2dGzkH0YeTNUwn4sDi2qMxKA6dHb5TtMgY1jMU=
 github.com/aws/aws-sdk-go v1.23.6 h1:8V9+bK/BzZh9CkmIzkT1USavOG17fMsWQpWFAMDt3ps=
 github.com/aws/aws-sdk-go v1.23.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.9 h1:WtVzerf5wSgPwlTTwl+ktCq/0GCS5MI9ZlLIcjsTr+Q=
@@ -328,6 +332,7 @@ github.com/joho/godotenv v1.2.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqx
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da h1:5y58+OCjoHCYB8182mpf/dEsq0vwTKPOo4zGfH0xW9A=
 github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da/go.mod h1:oLH0CmIaxCGXD67VKGR5AacGXZSMznlmeqM8RzPrcY8=
+github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.7/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.8/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=


### PR DESCRIPTION
Updated transportd version along with any reference to sdcli. Sdcli explicit declarations were changed from v1 to v1.1.1. 