### PR TITLE
update transportd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.12
 require (
 	github.com/asecurityteam/component-aws v0.1.0
 	github.com/asecurityteam/httpstats v0.0.0-20191007213332-05cb203c96fb // indirect
-	github.com/asecurityteam/transportd v1.0.1
+	github.com/asecurityteam/transportd v1.0.3
 	github.com/aws/aws-sdk-go v1.25.9
 	github.com/getkin/kin-openapi v0.2.1-0.20190729060947-8785b416cb32 // indirect
 	github.com/golang/mock v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -51,14 +51,10 @@ github.com/asecurityteam/settings v0.1.0/go.mod h1:Wb6bajm1AgHtjLP8ecv7RqUTCX1hv
 github.com/asecurityteam/settings v0.2.0/go.mod h1:frhlF5kT7WvdiRX3eQlCOjSppbYUfxxjM9xKTvYjcGo=
 github.com/asecurityteam/settings v0.4.0 h1:L7fK4WqkvnvglBrfLBgp77LUDR2cxfSNWGFex7lrMK0=
 github.com/asecurityteam/settings v0.4.0/go.mod h1:frhlF5kT7WvdiRX3eQlCOjSppbYUfxxjM9xKTvYjcGo=
-github.com/asecurityteam/transport v1.3.0 h1:UYcKPxnAEeGVkicefWtIL/nJys/BlwYUdNxLwvi49so=
-github.com/asecurityteam/transport v1.3.0/go.mod h1:nR1f2IiW3IIw2VxC7NOkZnwRhXanNE6XdnnIZctKbIU=
 github.com/asecurityteam/transport v1.3.1 h1:v3wG7xjq+RQMaZcv9sA5OmfaPx//PodClUKFK5oGPtw=
 github.com/asecurityteam/transport v1.3.1/go.mod h1:nR1f2IiW3IIw2VxC7NOkZnwRhXanNE6XdnnIZctKbIU=
-github.com/asecurityteam/transportd v1.0.0 h1:TwjruVMFpZ7mNSIsdKokwqjAhDtLRAQ76hTsmfLbvg4=
-github.com/asecurityteam/transportd v1.0.0/go.mod h1:mYu7W+jLQLEN7huup+JKPBLQGvA0+8+35Yu74G2wU+8=
-github.com/asecurityteam/transportd v1.0.1 h1:e7Yg6myAo1DsvNGtCKEi9ymf+M8W+3s2ixmiDKHVWL8=
-github.com/asecurityteam/transportd v1.0.1/go.mod h1:M1HNg2dGzkH0YeTNUwn4sDi2qMxKA6dHb5TtMgY1jMU=
+github.com/asecurityteam/transportd v1.0.3 h1:5s9He11MF7AO43b4Tpcfvfq2NXFvpH9hRCDa1sm+xm8=
+github.com/asecurityteam/transportd v1.0.3/go.mod h1:M1HNg2dGzkH0YeTNUwn4sDi2qMxKA6dHb5TtMgY1jMU=
 github.com/aws/aws-sdk-go v1.23.6 h1:8V9+bK/BzZh9CkmIzkT1USavOG17fMsWQpWFAMDt3ps=
 github.com/aws/aws-sdk-go v1.23.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.25.9 h1:WtVzerf5wSgPwlTTwl+ktCq/0GCS5MI9ZlLIcjsTr+Q=
@@ -330,8 +326,7 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=
 github.com/joho/godotenv v1.2.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
-github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da h1:5y58+OCjoHCYB8182mpf/dEsq0vwTKPOo4zGfH0xW9A=
-github.com/justinas/alice v0.0.0-20171023064455-03f45bd4b7da/go.mod h1:oLH0CmIaxCGXD67VKGR5AacGXZSMznlmeqM8RzPrcY8=
+github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
 github.com/justinas/alice v1.2.0/go.mod h1:fN5HRH/reO/zrUflLfTN43t3vXvKzvZIENsNEe7i7qA=
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/karrick/godirwalk v1.7.7/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=


### PR DESCRIPTION
This is necessary because transportd v1.0.3 has a fix for when open api spec docs have 

```
    security:
      - BearerAuth: []
```
