### PR TITLE
Template mapjoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ to generate a shape that can be serialized to JSON. The shape we inject is:
 {
     "Request": {
         "URL": {
-            "string": "string"
+            "string": "map[string]string"
         },
         "Query": {
             "string": ["string"]

--- a/pkg/component.go
+++ b/pkg/component.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
+	"strings"
 	"text/template"
 
 	awsc "github.com/asecurityteam/component-aws"
@@ -17,6 +19,23 @@ var (
 		"json": func(v interface{}) (string, error) {
 			b, err := json.Marshal(v)
 			return string(b), err
+		},
+		"mapJoin": func(pathParams map[string]string) string {
+			var keys []string
+			var sortedParams []string
+			//Idea is that we can reliably go param1, param2, param3 since maps are not guaranteed order
+			//This does rely on naming of the parameters though
+			for k := range pathParams {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+
+			//Sorted path parameters to run a join on
+			for _, k := range keys {
+				sortedParams = append(sortedParams, pathParams[k])
+			}
+
+			return strings.Join(sortedParams, "/")
 		},
 	}
 )

--- a/pkg/component.go
+++ b/pkg/component.go
@@ -20,7 +20,7 @@ var (
 			b, err := json.Marshal(v)
 			return string(b), err
 		},
-		"mapJoin": func(pathParams map[string]string) string {
+		"reduce": func(pathParams map[string]string) string {
 			var keys []string
 			var sortedParams []string
 			//Idea is that we can reliably go param1, param2, param3 since maps are not guaranteed order

--- a/pkg/component_test.go
+++ b/pkg/component_test.go
@@ -47,10 +47,8 @@ func TestComponentDoesNotAllowInvalidTemplates(t *testing.T) {
 
 func TestComponentTemplateFunctions(t *testing.T) {
 	jsonTemplate := `#! json . !#`
-	mapJoinTemplate := `#! mapJoin . !#`
+	reduceTemplate := `#! reduce . !#`
 	data := map[string]string{"r2": "sample", "r1": "app", "r3": "name"}
-
-	//TODO this could probably be a table driven one when I'm sure this works for ai-api
 
 	jt, err := template.New("jt").Funcs(fns).Delims("#!", "!#").Parse(jsonTemplate)
 	if err != nil {
@@ -65,15 +63,15 @@ func TestComponentTemplateFunctions(t *testing.T) {
 	expectedJSON := `{"r1":"app","r2":"sample","r3":"name"}`
 	assert.Equal(t, expectedJSON, jsonOutput.String())
 
-	var mapJoinOutput bytes.Buffer
-	mjt, err := template.New("mjt").Funcs(fns).Delims("#!", "!#").Parse(mapJoinTemplate)
+	var reduceOutput bytes.Buffer
+	rt, err := template.New("rt").Funcs(fns).Delims("#!", "!#").Parse(reduceTemplate)
 	if err != nil {
-		t.Error("Problem parsing map join test template")
+		t.Error("Problem parsing reduce test template")
 	}
-	err = mjt.Execute(&mapJoinOutput, data)
+	err = rt.Execute(&reduceOutput, data)
 	if err != nil {
-		t.Error("Problem running mapJoin custom template function")
+		t.Error("Problem running reduce custom template function")
 	}
-	expectedJoin := "app/sample/name"
-	assert.Equal(t, expectedJoin, mapJoinOutput.String())
+	expectedReduce := "app/sample/name"
+	assert.Equal(t, expectedReduce, reduceOutput.String())
 }

--- a/pkg/component_test.go
+++ b/pkg/component_test.go
@@ -3,9 +3,10 @@ package serverfullgw
 import (
 	"bytes"
 	"context"
-	"github.com/stretchr/testify/assert"
-	"text/template"
 	"testing"
+	"text/template"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestComponentDoesNotAllowInvalidTemplates(t *testing.T) {
@@ -61,8 +62,8 @@ func TestComponentTemplateFunctions(t *testing.T) {
 		t.Error("Problem running json custom template function")
 	}
 	//Json.Marshal orders the keys for us
-	expectedJson := `{"r1":"app","r2":"sample","r3":"name"}`
-	assert.Equal(t, expectedJson, jsonOutput.String())
+	expectedJSON := `{"r1":"app","r2":"sample","r3":"name"}`
+	assert.Equal(t, expectedJSON, jsonOutput.String())
 
 	var mapJoinOutput bytes.Buffer
 	mjt, err := template.New("mjt").Funcs(fns).Delims("#!", "!#").Parse(mapJoinTemplate)
@@ -70,7 +71,7 @@ func TestComponentTemplateFunctions(t *testing.T) {
 		t.Error("Problem parsing map join test template")
 	}
 	err = mjt.Execute(&mapJoinOutput, data)
-	if err!= nil {
+	if err != nil {
 		t.Error("Problem running mapJoin custom template function")
 	}
 	expectedJoin := "app/sample/name"

--- a/pkg/template.go
+++ b/pkg/template.go
@@ -75,7 +75,7 @@ func NewResponse(r *http.Response) (Response, error) {
 	}, nil
 }
 
-// NewRequest converts and http.Request into a template Request.
+// NewRequest converts an http.Request into a template Request.
 func NewRequest(urlParamFn func(context.Context) map[string]string, r *http.Request) (Request, error) {
 	d := make(map[string]interface{})
 	var b []byte


### PR DESCRIPTION
This adds a new custom template function that we can use to reduce a map[string]string to its values joined by forward slashes. Intended use is for the case where a resourceId search is tried when that id contains multiple forward slashes. Swagger will attempt to route based off these forward slashes, so our workaround is joining the path parameters that come in.

[This AI-API PR has an example of using this function.](https://github.com/asecurityteam/asset-inventory-api/pull/109) This PR also adds some coverage and updates the documentation that gave the wrong type for Request.URL. Request.URL is actually a map[string]string of all the pathParams received.

Sorting in the function might not be necessary, during testing even with out of order params it looked like Go tried to order them for you but from what I read online this isn't guaranteed.