### PR TITLE
Upgrade transportd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/asecurityteam/component-aws v0.1.0
-	github.com/asecurityteam/transportd v1.6.4
+	github.com/asecurityteam/transportd v1.6.5
 	github.com/aws/aws-sdk-go v1.38.61
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/asecurityteam/settings v0.4.0 h1:L7fK4WqkvnvglBrfLBgp77LUDR2cxfSNWGFe
 github.com/asecurityteam/settings v0.4.0/go.mod h1:frhlF5kT7WvdiRX3eQlCOjSppbYUfxxjM9xKTvYjcGo=
 github.com/asecurityteam/transport v1.6.5 h1:87W10yu/9k1ElLAGq0ieJUICY1ZDf6cnqBkU2p4xJ+A=
 github.com/asecurityteam/transport v1.6.5/go.mod h1:d9ISBYCWrAcVrF+2P5lK7ZVDRtC1waoKG1R5HM+QlDA=
-github.com/asecurityteam/transportd v1.6.4 h1:cT0V5fUZupM/W620lbInzkCvB9Ek4w3t5KQ/eMEt01w=
-github.com/asecurityteam/transportd v1.6.4/go.mod h1:qV/LYV/9s8jcKWQNbeyk1gs/qALjWvNVhGInLWAS5f4=
+github.com/asecurityteam/transportd v1.6.5 h1:kRuZIU0NuwwTXMhXKUBxfj3lPPFNUdIQr2VHJh0mKvw=
+github.com/asecurityteam/transportd v1.6.5/go.mod h1:qV/LYV/9s8jcKWQNbeyk1gs/qALjWvNVhGInLWAS5f4=
 github.com/aws/aws-sdk-go v1.23.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.38.61 h1:wizuqQZe0K4iYJ+Slrs0aSQ4P94FAwqBUHwk46Iz5UA=
 github.com/aws/aws-sdk-go v1.38.61/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=


### PR DESCRIPTION
This will fix the access logs consuming the response body without restoring it. Responses to error status codes should have content again.